### PR TITLE
Make dashboard league cards clickable to open the league

### DIFF
--- a/app/Http/Controllers/LeaguesController.php
+++ b/app/Http/Controllers/LeaguesController.php
@@ -108,6 +108,11 @@ class LeaguesController extends Controller
 
         $user->update(['current_league_id' => $league->id]);
 
+        // "Enter" the league (e.g. clicking its dashboard card) lands on the roster.
+        if ($request->boolean('enter')) {
+            return redirect()->route('golfers.index');
+        }
+
         return back()->with('success', "Switched to “{$league->name}”.");
     }
 }

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -80,8 +80,13 @@ function submit() {
     form.post(route('leagues.store'), { preserveScroll: true });
 }
 
-function switchTo(id) {
-    router.post(route('leagues.switch', id), {}, { preserveScroll: true });
+// Clicking a league card opens it: switch to it if needed, then land on the roster.
+function openLeague(league) {
+    if (league.is_current) {
+        router.visit(route('golfers.index'));
+    } else {
+        router.post(route('leagues.switch', league.id), { enter: true });
+    }
 }
 
 /* ---------- rename ---------- */
@@ -139,10 +144,16 @@ function submitDelete() {
                     <div
                         v-for="league in leagues"
                         :key="league.id"
-                        class="flex items-center justify-between gap-3 rounded-2xl border border-parchment-dark bg-cream p-5 shadow-sm"
+                        role="button"
+                        tabindex="0"
+                        @click="openLeague(league)"
+                        @keydown.enter="openLeague(league)"
+                        @keydown.space.prevent="openLeague(league)"
+                        :aria-label="`Open ${league.name}`"
+                        class="group flex cursor-pointer items-center justify-between gap-3 rounded-2xl border border-parchment-dark bg-cream p-5 shadow-sm transition hover:border-brass hover:shadow-md focus:outline-none focus:ring-2 focus:ring-brass focus:ring-offset-2 focus:ring-offset-parchment"
                     >
                         <div class="min-w-0">
-                            <p class="truncate font-display text-lg font-semibold text-pine">
+                            <p class="truncate font-display text-lg font-semibold text-pine transition group-hover:text-brass-dark">
                                 {{ league.name }}
                             </p>
                             <p class="mt-0.5 text-xs text-ink/50">
@@ -155,7 +166,7 @@ function submitDelete() {
                             <button
                                 v-if="league.role === 'admin'"
                                 type="button"
-                                @click="openRename(league)"
+                                @click.stop="openRename(league)"
                                 :aria-label="`Rename ${league.name}`"
                                 class="rounded-full p-1.5 text-pine/60 transition hover:bg-pine/10 hover:text-pine"
                             >
@@ -166,7 +177,7 @@ function submitDelete() {
                             <button
                                 v-if="league.role === 'admin'"
                                 type="button"
-                                @click="openDelete(league)"
+                                @click.stop="openDelete(league)"
                                 :aria-label="`Delete ${league.name}`"
                                 class="rounded-full p-1.5 text-red-700/70 transition hover:bg-red-700/10 hover:text-red-700"
                             >
@@ -180,14 +191,16 @@ function submitDelete() {
                             >
                                 Current
                             </span>
-                            <button
-                                v-else
-                                type="button"
-                                @click="switchTo(league.id)"
-                                class="rounded-full border border-pine/20 px-4 py-1.5 text-sm font-medium text-pine transition hover:border-brass hover:text-brass-dark"
+                            <svg
+                                class="h-5 w-5 text-pine/40 transition group-hover:translate-x-0.5 group-hover:text-brass"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                aria-hidden="true"
                             >
-                                Switch
-                            </button>
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                            </svg>
                         </div>
                     </div>
                 </div>

--- a/tests/Feature/LeagueManagementTest.php
+++ b/tests/Feature/LeagueManagementTest.php
@@ -239,6 +239,21 @@ class LeagueManagementTest extends TestCase
         $this->assertSame($b->id, $user->fresh()->current_league_id);
     }
 
+    public function test_entering_a_league_switches_and_redirects_to_the_roster(): void
+    {
+        $a = League::factory()->create();
+        $b = League::factory()->create();
+        $user = User::factory()->create(['current_league_id' => $a->id]);
+        $a->members()->attach($user->id, ['role' => 'admin']);
+        $b->members()->attach($user->id, ['role' => 'admin']);
+
+        $this->actingAs($user)
+            ->post(route('leagues.switch', $b), ['enter' => true])
+            ->assertRedirect(route('golfers.index'));
+
+        $this->assertSame($b->id, $user->fresh()->current_league_id);
+    }
+
     public function test_cannot_switch_to_a_league_you_are_not_in(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
Clicking a league card now opens it: the current league goes to the roster, and another league switches to it and lands on its roster in one navigation (new 'enter' flag on leagues.switch). Rename/delete buttons stop propagation; the Switch button is replaced by a chevron affordance. Card is keyboard-accessible.