### PR TITLE
Brand browser tab titles as GolfTourney instead of Laravel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME=GolfTourney
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,7 +6,7 @@ import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createApp, h } from 'vue';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 
-const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+const appName = import.meta.env.VITE_APP_NAME || 'GolfTourney';
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title inertia>{{ config('app.name', 'Laravel') }}</title>
+        <title inertia>{{ config('app.name', 'GolfTourney') }}</title>
 
         <!-- Favicon -->
         <link rel="icon" href="{{ asset('favicon.svg') }}" type="image/svg+xml">


### PR DESCRIPTION
The Inertia title template fell back to 'Laravel' (VITE_APP_NAME unset, and the CI build has no .env), so tabs read 'Golfers - Laravel'. Default the app name to GolfTourney in app.js and the blade title fallback, and set APP_NAME in .env.example.