### PR TITLE
Course search: match club_name; show course name as a secondary line

### DIFF
--- a/app/Http/Controllers/CoursesController.php
+++ b/app/Http/Controllers/CoursesController.php
@@ -25,8 +25,8 @@ class CoursesController extends Controller
         }
 
         $courses = Course::query()
-            ->where('course_name', 'like', '%'.$term.'%')
-            ->orderBy('course_name')
+            ->where('club_name', 'like', '%'.$term.'%')
+            ->orderBy('club_name')
             ->limit(12)
             ->get(['id', 'course_name', 'club_name', 'state', 'postal_code', 'layout_data']);
 

--- a/resources/js/Components/CourseSearch.vue
+++ b/resources/js/Components/CourseSearch.vue
@@ -67,7 +67,7 @@ async function runSearch(term) {
 
 function choose(course) {
     emit('select', course);
-    query.value = course.name;
+    query.value = course.club || course.name;
     results.value = [];
     open.value = false;
 }
@@ -184,7 +184,13 @@ onBeforeUnmount(() => {
                 class="cursor-pointer px-4 py-2.5"
                 :class="i === activeIndex ? 'bg-parchment' : ''"
             >
-                <p class="font-medium text-ink">{{ course.name }}</p>
+                <p class="font-medium text-ink">{{ course.club || course.name }}</p>
+                <p
+                    v-if="course.name && course.club && course.name !== course.club"
+                    class="mt-0.5 text-xs text-ink/70"
+                >
+                    {{ course.name }}
+                </p>
                 <p class="mt-0.5 text-xs text-ink/50">
                     <span v-if="course.location">{{ course.location }}</span>
                     <span v-if="course.teeboxes.length"> · {{ course.teeboxes.length }} tee{{ course.teeboxes.length === 1 ? '' : 's' }}</span>

--- a/tests/Feature/LeagueManagementTest.php
+++ b/tests/Feature/LeagueManagementTest.php
@@ -27,6 +27,7 @@ class LeagueManagementTest extends TestCase
     public function test_course_search_returns_matches_with_teeboxes(): void
     {
         Course::factory()->create([
+            'club_name' => 'Pine Valley Country Club',
             'course_name' => 'Pine Valley Golf Club',
             'layout_data' => [
                 'hole_count' => 18,
@@ -42,6 +43,7 @@ class LeagueManagementTest extends TestCase
         $this->actingAs(User::factory()->create())
             ->getJson(route('courses.search', ['q' => 'Pine']))
             ->assertOk()
+            ->assertJsonPath('courses.0.club', 'Pine Valley Country Club')
             ->assertJsonPath('courses.0.name', 'Pine Valley Golf Club')
             ->assertJsonPath('courses.0.holes', 18)
             ->assertJsonPath('courses.0.teeboxes.0.name', 'Blue')
@@ -50,12 +52,36 @@ class LeagueManagementTest extends TestCase
             ->assertJsonPath('courses.0.teeboxes.0.rating', 72.1);
     }
 
+    public function test_course_search_matches_club_name_not_course_name(): void
+    {
+        Course::factory()->create([
+            'club_name' => 'Augusta National',
+            'course_name' => 'Magnolia Championship Layout',
+        ]);
+
+        $user = User::factory()->create();
+
+        // A term in the club name matches…
+        $this->actingAs($user)
+            ->getJson(route('courses.search', ['q' => 'Augusta']))
+            ->assertOk()
+            ->assertJsonPath('courses.0.club', 'Augusta National')
+            ->assertJsonPath('courses.0.name', 'Magnolia Championship Layout');
+
+        // …but a term that appears only in the course name does not.
+        $this->actingAs($user)
+            ->getJson(route('courses.search', ['q' => 'Magnolia']))
+            ->assertOk()
+            ->assertExactJson(['courses' => []]);
+    }
+
     public function test_course_search_halves_doubled_nine_hole_ratings(): void
     {
         // Robert A. Black: a 9-hole course whose rating (63) was doubled by the
         // source API. Par sums to 33, so 63 is closer to 2*par (66) than par —
         // it must come back halved to the true 31.5.
         Course::factory()->create([
+            'club_name' => 'Robert A. Black',
             'course_name' => 'Robert A. Black',
             'layout_data' => [
                 'hole_count' => 9,
@@ -81,6 +107,7 @@ class LeagueManagementTest extends TestCase
         // An already-correct 9-hole rating (33.6 vs par 35) must NOT be halved —
         // the par anchor guards against double-halving.
         Course::factory()->create([
+            'club_name' => 'Little Miami Golf Center',
             'course_name' => 'Little Miami Golf Center',
             'layout_data' => [
                 'hole_count' => 9,


### PR DESCRIPTION
Search the catalog by club_name instead of course_name and order by it. In the autocomplete, show the club name as the primary label and, when the course name differs, render it on its own line between the club name and the state/tee meta. Update search tests to seed/search club_name and add a test locking in that course_name is not matched.