### PR TITLE
Dashboard: show the league's course on its card, drop the role badge

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -23,8 +23,9 @@ class DashboardController extends Controller
 
         $leagues = DB::table('leagues as l')
             ->join('league_user as lu', 'lu.league_id', '=', 'l.id')
+            ->leftJoin('courses as c', 'c.id', '=', 'l.course_id')
             ->where('lu.user_id', $user->id)
-            ->select('l.id', 'l.name', 'lu.role', 'l.course_rating', 'l.slope_rating')
+            ->select('l.id', 'l.name', 'lu.role', 'l.course_rating', 'l.slope_rating', 'c.club_name', 'c.course_name')
             ->selectSub(
                 DB::table('golfer_league')->selectRaw('count(*)')->whereColumn('golfer_league.league_id', 'l.id'),
                 'golfers_count'
@@ -35,6 +36,8 @@ class DashboardController extends Controller
                 'id' => $l->id,
                 'name' => $l->name,
                 'role' => $l->role,
+                'club_name' => $l->club_name,
+                'course_name' => $l->course_name,
                 'course_rating' => $l->course_rating,
                 'slope_rating' => $l->slope_rating,
                 'golfers_count' => $l->golfers_count,

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -150,9 +150,17 @@ function submitDelete() {
                             <p class="text-lg font-semibold truncate transition font-display text-pine group-hover:text-brass-dark">
                                 {{ league.name }}
                             </p>
+                            <p v-if="league.club_name" class="mt-0.5 text-sm truncate text-ink/70">
+                                {{ league.club_name }}
+                            </p>
+                            <p
+                                v-if="league.course_name && league.course_name !== league.club_name"
+                                class="text-xs truncate text-ink/50"
+                            >
+                                {{ league.course_name }}
+                            </p>
                             <p class="mt-0.5 text-xs text-ink/50">
-                                <span class="tracking-wider uppercase text-brass-dark">{{ league.role }}</span>
-                                · {{ league.golfers_count }} golfers
+                                {{ league.golfers_count }} golfers
                                 · rating {{ league.course_rating }} / slope {{ league.slope_rating }}
                             </p>
                         </div>

--- a/tests/Feature/LeagueManagementTest.php
+++ b/tests/Feature/LeagueManagementTest.php
@@ -306,4 +306,20 @@ class LeagueManagementTest extends TestCase
                 ->where('leagues.0.is_current', true)
             );
     }
+
+    public function test_dashboard_exposes_the_leagues_course_club_and_name(): void
+    {
+        $course = Course::factory()->create([
+            'club_name' => 'Augusta National',
+            'course_name' => 'Magnolia Course',
+        ]);
+        $league = League::factory()->create(['course_id' => $course->id]);
+
+        $this->actingAs($this->adminOf($league))
+            ->get(route('dashboard'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('leagues.0.club_name', 'Augusta National')
+                ->where('leagues.0.course_name', 'Magnolia Course')
+            );
+    }
 }


### PR DESCRIPTION
Left-join the catalog course into the leagues payload and surface club_name (and course_name when it differs, mirroring the course-search results) under each league name. Remove the ADMIN/role badge from the card meta line; role is still used to gate the edit/delete actions. Add a test for the new fields.