### PR TITLE
Roster onboarding + league teardown polish

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -26,7 +26,7 @@ class DashboardController extends Controller
             ->join('league_user as lu', 'lu.league_id', '=', 'l.id')
             ->leftJoin('courses as c', 'c.id', '=', 'l.course_id')
             ->where('lu.user_id', $user->id)
-            ->select('l.id', 'l.name', 'lu.role', 'l.course_rating', 'l.slope_rating', 'c.club_name', 'c.course_name', 'l.league_only', 'l.display_nine_hole_index')
+            ->select('l.id', 'l.name', 'lu.role', 'l.owner_id', 'l.course_rating', 'l.slope_rating', 'c.club_name', 'c.course_name', 'l.league_only', 'l.display_nine_hole_index')
             ->selectSub(
                 DB::table('league_user')->selectRaw('count(*)')->whereColumn('league_user.league_id', 'l.id'),
                 'golfers_count'
@@ -43,6 +43,7 @@ class DashboardController extends Controller
                 'slope_rating' => $l->slope_rating,
                 'golfers_count' => $l->golfers_count,
                 'is_current' => $l->id === $user->current_league_id,
+                'is_owner' => $l->owner_id === $user->id,
                 'league_only' => (bool) $l->league_only,
                 'display_nine_hole_index' => (bool) $l->display_nine_hole_index,
             ]);

--- a/app/Http/Controllers/GolfersController.php
+++ b/app/Http/Controllers/GolfersController.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -332,10 +333,23 @@ class GolfersController extends Controller
     /**
      * Remove a golfer from the current league. Login-less roster users left with
      * no leagues are deleted entirely; login accounts are only detached.
+     *
+     * Removing the league's owner (the admin who created it) has no other admin
+     * to hand off to, so it tears the whole league down instead — see
+     * dissolveLeague().
      */
     public function destroy(Request $request, User $user): RedirectResponse
     {
         $league = $this->authorizeUser($request, $user);
+
+        // Removing the owner deletes the league — only the owner may do it to
+        // their own league, so another admin can't tear it down out from under
+        // them (nor orphan it by detaching the owner without a teardown).
+        if ($user->id === $league->owner_id) {
+            abort_unless($request->user()->id === $league->owner_id, 403);
+
+            return $this->dissolveLeague($league);
+        }
 
         $user->rounds()->where('league_id', $league->id)->delete();
         $user->leagues()->detach($league->id);
@@ -350,20 +364,57 @@ class GolfersController extends Controller
     }
 
     /**
-     * Invite a roster player to set up a login: email them a set-password link
-     * (and surface it to the admin to copy, since mail delivery isn't assured).
+     * Tear down a league when its owner leaves: remove every member (league_user)
+     * and delete the league, but keep everyone's rounds by detaching them into
+     * standalone casual rounds (rounds are self-contained, so they stay scoreable
+     * without a league). No users are deleted — that would cascade their rounds.
+     */
+    private function dissolveLeague(League $league): RedirectResponse
+    {
+        $name = $league->name;
+
+        // Keeps everyone's rounds as casual rounds and reselects a next league.
+        $league->dissolve();
+
+        return redirect()->route('leagues')
+            ->with('success', "“{$name}” was deleted. Members’ rounds were kept.");
+    }
+
+    /**
+     * Invite a roster player to set up a login: confirm/update their email (it
+     * must be unique across accounts), then email them a set-password link (and
+     * surface it to the admin to copy, since mail delivery isn't assured). Also
+     * used to resend — invited_at is stamped each time.
      */
     public function invite(Request $request, User $user): RedirectResponse
     {
         $this->authorizeUser($request, $user);
 
         if ($user->canLogin()) {
-            throw ValidationException::withMessages(['invite' => 'This golfer already has a login.']);
+            throw ValidationException::withMessages(['email' => 'This golfer already has a login.']);
         }
 
-        if (! $user->email || str_ends_with($user->email, '@noreply.com')) {
-            throw ValidationException::withMessages(['invite' => 'Add the player’s real email before inviting them.']);
+        $email = trim((string) $request->validate([
+            'email' => ['required', 'email', 'max:255'],
+        ])['email']);
+
+        // Placeholder noreply addresses (used for login-less roster golfers) can't
+        // receive an invite — the admin must supply a real, reachable email.
+        if (str_ends_with(mb_strtolower($email), '@noreply.com')) {
+            throw ValidationException::withMessages(['email' => 'Enter a real email — a noreply address can’t receive an invite.']);
         }
+
+        // An email uniquely identifies a person, so it can't already belong to a
+        // different account (case-insensitive, matching how we dedup elsewhere).
+        $taken = User::whereRaw('lower(email) = ?', [mb_strtolower($email)])
+            ->where('id', '!=', $user->id)
+            ->exists();
+
+        if ($taken) {
+            throw ValidationException::withMessages(['email' => 'This email is already in use.']);
+        }
+
+        $user->update(['email' => $email]);
 
         $token = Password::broker('invites')->createToken($user);
 
@@ -381,6 +432,11 @@ class GolfersController extends Controller
             ]);
         }
 
+        $user->update(['invited_at' => now()]);
+
+        // Email + invite state changed, so every roster this golfer is on is stale.
+        $user->leagues()->get()->each->forgetRosterCache();
+
         return back()
             ->with('success', $delivered
                 ? "Invitation sent to {$user->email}."
@@ -392,14 +448,14 @@ class GolfersController extends Controller
      * The league roster: each member with their per-league round count, portable
      * Handicap Index (formatted + raw for sorting), and derived Course Handicap.
      *
-     * @return list<array{id: int, first_name: string, last_name: string, email: ?string, phone: ?string, number_of_rounds: int, index: string, index_value: ?float, manual_handicap_index: ?float, has_computed_index: bool, course_handicap: ?int, can_login: bool}>
+     * @return list<array{id: int, first_name: string, last_name: string, email: ?string, phone: ?string, number_of_rounds: int, index: string, index_value: ?float, manual_handicap_index: ?float, has_computed_index: bool, course_handicap: ?int, can_login: bool, invited_at: ?string}>
      */
     private function rosterFor(League $league): array
     {
         $rows = DB::table('users as u')
             ->join('league_user as lu', 'lu.user_id', '=', 'u.id')
             ->where('lu.league_id', $league->id)
-            ->select('u.id', 'u.first_name', 'u.last_name', 'u.email', 'u.phone', 'u.handicap_index', 'u.manual_handicap_index')
+            ->select('u.id', 'u.first_name', 'u.last_name', 'u.email', 'u.phone', 'u.handicap_index', 'u.manual_handicap_index', 'u.invited_at')
             ->selectRaw('(u.password is not null) as can_login')
             ->selectSub(
                 DB::table('rounds')
@@ -445,6 +501,8 @@ class GolfersController extends Controller
                 'has_computed_index' => ! is_null($r->handicap_index),
                 'course_handicap' => $this->handicaps->courseHandicapForIndex($effective, $league),
                 'can_login' => (bool) $r->can_login,
+                // When they were last sent a login invite (null = never / accepted).
+                'invited_at' => $r->invited_at ? Carbon::parse($r->invited_at)->format('M j, Y') : null,
             ];
         })->values()->all();
     }

--- a/app/Http/Controllers/LeaguesController.php
+++ b/app/Http/Controllers/LeaguesController.php
@@ -5,11 +5,8 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreLeagueRequest;
 use App\Models\Course;
 use App\Models\League;
-use App\Models\Round;
-use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class LeaguesController extends Controller
 {
@@ -98,40 +95,15 @@ class LeaguesController extends Controller
      */
     public function destroy(Request $request, League $league): RedirectResponse
     {
-        abort_unless($request->user()->isAdminOf($league), 403);
+        // Only the creator (owner) may delete a league they made.
+        abort_unless($request->user()->id === $league->owner_id, 403);
 
         $name = $league->name;
 
-        DB::transaction(function () use ($league) {
-            // This league's rounds.
-            Round::where('league_id', $league->id)->delete();
+        // Keeps everyone's rounds as casual rounds and reselects a next league.
+        $league->dissolve();
 
-            // Detach members; delete any login-less roster user left leagueless.
-            $memberIds = DB::table('league_user')
-                ->where('league_id', $league->id)
-                ->pluck('user_id');
-            $league->members()->detach();
-
-            foreach ($memberIds as $memberId) {
-                $stillMember = DB::table('league_user')
-                    ->where('user_id', $memberId)
-                    ->exists();
-
-                if (! $stillMember) {
-                    User::whereKey($memberId)->whereNull('password')->delete();
-                }
-            }
-
-            // Anyone pointing at this as their current league.
-            User::where('current_league_id', $league->id)
-                ->update(['current_league_id' => null]);
-
-            $league->delete();
-        });
-
-        $league->forgetRosterCache();
-
-        return redirect()->route('leagues')->with('success', "“{$name}” deleted.");
+        return redirect()->route('leagues')->with('success', "“{$name}” deleted. Members’ rounds were kept.");
     }
 
     /**

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -48,6 +48,7 @@ class HandleInertiaRequests extends Middleware
                     'current_league' => $league ? [
                         'id' => $league->id,
                         'name' => $league->name,
+                        'owner_id' => $league->owner_id,
                     ] : null,
                     // The user's leagues, for the nav switcher.
                     'leagues' => DB::table('league_user as lu')

--- a/app/Http/Requests/UpdateGolferRequest.php
+++ b/app/Http/Requests/UpdateGolferRequest.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests;
 
-use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateGolferRequest extends FormRequest
@@ -20,29 +19,16 @@ class UpdateGolferRequest extends FormRequest
      */
     public function rules(): array
     {
-        // Until a golfer has enough rounds to compute an index (handicap_index
-        // stays null below the 3-round minimum), an established index is the
-        // only way to gauge their play, so it's required. Once computed, the
-        // field is locked and any submitted value is ignored.
-        $user = $this->route('user');
-        $needsSeed = $user instanceof User && $user->handicap_index === null;
-
+        // The established index is an optional seed: while a golfer has too few
+        // rounds to compute an index (handicap_index stays null below the
+        // 3-round minimum) it's how you can gauge their play, but it's never
+        // required. Once computed, the field is locked and any value is ignored.
         return [
             'first_name' => 'required|string|max:255',
             'last_name' => 'required|string|max:255',
             'email' => 'nullable|email|max:255',
             'phone' => 'nullable|string|max:255',
-            'manual_handicap_index' => [$needsSeed ? 'required' : 'nullable', 'numeric', 'between:-9.9,54.0'],
-        ];
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function messages(): array
-    {
-        return [
-            'manual_handicap_index.required' => 'An established index is required until this golfer has 3 rounds logged.',
+            'manual_handicap_index' => ['nullable', 'numeric', 'between:-9.9,54.0'],
         ];
     }
 }

--- a/app/Models/League.php
+++ b/app/Models/League.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class League extends Model
 {
@@ -91,7 +92,7 @@ class League extends Model
      * field), so old forever-cached payloads are abandoned on deploy instead of
      * serving a stale shape.
      */
-    public const ROSTER_CACHE_VERSION = 2;
+    public const ROSTER_CACHE_VERSION = 3;
 
     /**
      * Cache key for this league's golfer roster (the Golfers/Index payload).
@@ -108,5 +109,39 @@ class League extends Model
     public function forgetRosterCache(): void
     {
         Cache::forget($this->rosterCacheKey());
+    }
+
+    /**
+     * Tear this league down: keep everyone's history by detaching this league's
+     * rounds into standalone casual rounds, remove every membership, move anyone
+     * parked here onto their next available league (or none), then delete the
+     * league. No users are deleted — that would cascade their rounds.
+     */
+    public function dissolve(): void
+    {
+        DB::transaction(function () {
+            // Keep the history: league rounds live on as casual rounds.
+            $this->rounds()->update(['league_id' => null]);
+
+            // Everyone currently viewing this league; move them off it once gone.
+            $strandedIds = User::where('current_league_id', $this->id)->pluck('id');
+
+            $this->members()->detach();
+
+            foreach ($strandedIds as $userId) {
+                // Their next league, ordered like the nav switcher (by name).
+                $next = DB::table('league_user as lu')
+                    ->join('leagues as l', 'l.id', '=', 'lu.league_id')
+                    ->where('lu.user_id', $userId)
+                    ->orderBy('l.name')
+                    ->value('lu.league_id');
+
+                User::whereKey($userId)->update(['current_league_id' => $next]);
+            }
+
+            $this->delete();
+        });
+
+        $this->forgetRosterCache();
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,7 @@ class User extends Authenticatable
         'handicap_index',
         'manual_handicap_index',
         'password',
+        'invited_at',
         'created_at',
         'updated_at',
     ];
@@ -52,6 +53,7 @@ class User extends Authenticatable
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'invited_at' => 'datetime',
         'password' => 'hashed',
         'handicap_index' => 'decimal:1',
         'manual_handicap_index' => 'decimal:1',

--- a/database/migrations/2026_06_28_000001_add_invited_at_to_users_table.php
+++ b/database/migrations/2026_06_28_000001_add_invited_at_to_users_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * When an admin last emailed this roster player a set-up invite, so the
+     * roster can show "Invited …" and offer a resend. Stays null once they've
+     * accepted (they have a login) or were never invited.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('invited_at')->nullable()->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('invited_at');
+        });
+    }
+};

--- a/resources/js/Components/FlashToast.vue
+++ b/resources/js/Components/FlashToast.vue
@@ -1,0 +1,42 @@
+<script setup>
+import { ref, watch } from 'vue';
+import { usePage } from '@inertiajs/vue3';
+
+/**
+ * Global success toast: the small pine pill that slides up from the bottom
+ * whenever a request flashes `success`. Mounted once in AuthenticatedLayout,
+ * so any page (or redirect) that flashes a message gets it automatically.
+ */
+const page = usePage();
+const toast = ref('');
+let toastTimer;
+
+watch(
+    () => page.props.flash?.success,
+    (msg) => {
+        if (!msg) return;
+        toast.value = msg;
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => (toast.value = ''), 3200);
+    },
+    { immediate: true },
+);
+</script>
+
+<template>
+    <Transition
+        enter-active-class="transition duration-300 ease-out"
+        enter-from-class="translate-y-2 opacity-0"
+        leave-active-class="transition duration-200 ease-in"
+        leave-to-class="translate-y-2 opacity-0"
+    >
+        <div
+            v-if="toast"
+            role="status"
+            aria-live="polite"
+            class="fixed z-50 px-5 -translate-x-1/2 rounded-full shadow-lg bottom-6 left-1/2 py-2.5 text-sm font-medium bg-pine text-cream"
+        >
+            {{ toast }}
+        </div>
+    </Transition>
+</template>

--- a/resources/js/Components/Rounds/RoundHistory.vue
+++ b/resources/js/Components/Rounds/RoundHistory.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { computed, ref, watch } from 'vue';
-import { useForm, usePage } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+import { useForm } from '@inertiajs/vue3';
 import VueDatePicker from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 import Modal from '@/Components/Modal.vue';
@@ -29,8 +29,6 @@ const props = defineProps({
     // Optional subtitle on the create modal, e.g. "For john milne".
     forLabel: { type: String, default: '' },
 });
-
-const page = usePage();
 
 const countingSet = computed(() => new Set(props.usedRoundIds));
 const counts = (id) => countingSet.value.has(id);
@@ -83,18 +81,6 @@ function primarySortClass(field) {
         : `${base} border-pine/20 text-pine hover:border-brass`;
 }
 
-/* ---------- flash toast ---------- */
-const toast = ref('');
-let toastTimer;
-watch(
-    () => page.props.flash?.success,
-    (msg) => {
-        if (!msg) return;
-        toast.value = msg;
-        clearTimeout(toastTimer);
-        toastTimer = setTimeout(() => (toast.value = ''), 3200);
-    },
-);
 
 /* ---------- create ---------- */
 const showCreate = ref(false);
@@ -296,20 +282,6 @@ defineExpose({ openCreate });
             @update:page="setPage"
         />
 
-        <!-- Toast -->
-        <Transition
-            enter-active-class="transition duration-300 ease-out"
-            enter-from-class="translate-y-2 opacity-0"
-            leave-active-class="transition duration-200 ease-in"
-            leave-to-class="translate-y-2 opacity-0"
-        >
-            <div
-                v-if="toast"
-                class="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-full bg-pine px-5 py-2.5 text-sm font-medium text-cream shadow-lg"
-            >
-                {{ toast }}
-            </div>
-        </Transition>
 
         <!-- Create modal -->
         <Modal :show="showCreate" @close="showCreate = false" max-width="md">

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import Dropdown from '@/Components/Dropdown.vue';
 import DropdownLink from '@/Components/DropdownLink.vue';
 import ResponsiveNavLink from '@/Components/ResponsiveNavLink.vue';
+import FlashToast from '@/Components/FlashToast.vue';
 import { Link, router, usePage } from '@inertiajs/vue3';
 
 const showingNavigationDropdown = ref(false);
@@ -231,5 +232,8 @@ function switchLeague(id) {
         <main>
             <slot />
         </main>
+
+        <!-- Global success toast (any page/redirect that flashes `success`). -->
+        <FlashToast />
     </div>
 </template>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -213,7 +213,7 @@ function submitDelete() {
                                 </svg>
                             </button>
                             <button
-                                v-if="league.role === 'admin'"
+                                v-if="league.is_owner"
                                 type="button"
                                 @click.stop="openDelete(league)"
                                 :aria-label="`Delete ${league.name}`"

--- a/resources/js/Pages/Golfers/Index.vue
+++ b/resources/js/Pages/Golfers/Index.vue
@@ -19,6 +19,8 @@ const props = defineProps({
 
 const page = usePage();
 const isAdmin = computed(() => page.props.auth.user?.role === 'admin');
+const currentLeague = computed(() => page.props.auth.user?.current_league ?? null);
+const ownerId = computed(() => currentLeague.value?.owner_id ?? null);
 
 /* ---------- search + sort + pagination ---------- */
 const sortable = [
@@ -60,19 +62,6 @@ const exportUrl = computed(() =>
         dir: sortDir.value,
         search: search.value || undefined,
     }),
-);
-
-/* ---------- flash toast ---------- */
-const toast = ref('');
-let toastTimer;
-watch(
-    () => page.props.flash?.success,
-    (msg) => {
-        if (!msg) return;
-        toast.value = msg;
-        clearTimeout(toastTimer);
-        toastTimer = setTimeout(() => (toast.value = ''), 3200);
-    },
 );
 
 /* ---------- create ---------- */
@@ -120,9 +109,20 @@ function submitEdit() {
 }
 
 /* ---------- invite to log in ---------- */
-const inviteForm = useForm({});
+const showInvite = ref(false);
+const inviting = ref(null);
+const inviteForm = useForm({ email: '' });
+function openInvite(golfer) {
+    inviting.value = golfer;
+    inviteForm.clearErrors();
+    inviteForm.email = golfer.email ?? '';
+    showInvite.value = true;
+}
 function sendInvite() {
-    inviteForm.post(route('golfers.invite', editing.value.id), { preserveScroll: true });
+    inviteForm.post(route('golfers.invite', inviting.value.id), {
+        preserveScroll: true,
+        onSuccess: () => (showInvite.value = false),
+    });
 }
 
 // Surface the invite link the server returns (mail-delivery fallback).
@@ -136,7 +136,7 @@ watch(
         inviteLink.value = link;
         linkCopied.value = false;
         showInviteLink.value = true;
-        showEdit.value = false;
+        showInvite.value = false;
     },
 );
 function copyInviteLink() {
@@ -152,6 +152,8 @@ function openDelete(golfer) {
     deleting.value = golfer;
     showDelete.value = true;
 }
+// Removing the league's creator dissolves the whole league (see destroy()).
+const deletingOwner = computed(() => !!deleting.value && deleting.value.id === ownerId.value);
 function submitDelete() {
     deleteForm.delete(route('golfers.destroy', deleting.value.id), {
         preserveScroll: true,
@@ -292,7 +294,6 @@ function toggleExpand(id) {
                                     </button>
                                 </th>
                                 <th scope="col" class="px-5 py-3 text-xs font-semibold tracking-wider uppercase text-pine">Email</th>
-                                <th scope="col" class="px-5 py-3 text-xs font-semibold tracking-wider uppercase text-pine">Phone</th>
                                 <th v-if="isAdmin" scope="col" class="px-5 py-3 text-xs font-semibold tracking-wider text-right uppercase text-pine">
                                     <span class="sr-only">Actions</span>
                                 </th>
@@ -322,35 +323,67 @@ function toggleExpand(id) {
                                 <td class="px-5 py-3.5 font-display tabular-nums text-ink/80">{{ g.course_handicap ?? '—' }}</td>
                                 <td class="px-5 py-3.5 tabular-nums text-ink/80">{{ g.number_of_rounds }}</td>
                                 <td class="px-5 py-3.5 text-ink/70">{{ g.email || '—' }}</td>
-                                <td class="px-5 py-3.5 tabular-nums text-ink/70">{{ g.phone || '—' }}</td>
                                 <td v-if="isAdmin" class="px-5 py-3.5">
-                                    <div class="flex items-center justify-end gap-1 transition opacity-60 group-hover:opacity-100">
-                                        <button
-                                            type="button"
-                                            @click="openEdit(g)"
-                                            class="rounded-full p-1.5 text-pine transition hover:bg-pine/10"
-                                            :aria-label="`Edit ${fullName(g)}`"
+                                    <div class="flex items-center justify-end gap-2">
+                                        <!-- Login status / invite (always visible) -->
+                                        <span
+                                            v-if="g.can_login"
+                                            class="inline-flex items-center gap-1.5 rounded-full bg-pine/10 px-2.5 py-1 text-xs font-medium text-pine"
+                                            title="This golfer has an active login"
                                         >
-                                            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4 12.5-12.5z" />
-                                            </svg>
-                                        </button>
+                                            <span class="h-1.5 w-1.5 rounded-full bg-pine"></span> Active
+                                        </span>
+                                        <template v-else-if="g.invited_at">
+                                            <button
+                                                type="button"
+                                                @click="openInvite(g)"
+                                                title="Invite sent — click to resend"
+                                                class="inline-flex items-center gap-1.5 rounded-full border border-brass/40 bg-brass/15 px-2.5 py-1 text-xs font-medium text-brass-dark transition hover:bg-brass/25"
+                                            >
+                                                <span class="h-1.5 w-1.5 rounded-full bg-brass-dark"></span> Invite sent
+                                            </button>
+                                        </template>
                                         <button
+                                            v-else
                                             type="button"
-                                            @click="openDelete(g)"
-                                            class="rounded-full p-1.5 text-red-700 transition hover:bg-red-700/10"
-                                            :aria-label="`Delete ${fullName(g)}`"
+                                            @click="openInvite(g)"
+                                            class="inline-flex items-center gap-1.5 rounded-full border border-pine/30 px-2.5 py-1 text-xs font-medium text-pine transition hover:border-brass hover:text-brass-dark"
                                         >
-                                            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16M10 11v6M14 11v6M5 7l1 13a2 2 0 002 2h8a2 2 0 002-2l1-13M9 7V4h6v3" />
+                                            <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                                             </svg>
+                                            Send Invite
                                         </button>
+
+                                        <!-- Edit / delete (surface on hover) -->
+                                        <div class="flex items-center gap-1 transition opacity-60 group-hover:opacity-100">
+                                            <button
+                                                type="button"
+                                                @click="openEdit(g)"
+                                                class="rounded-full p-1.5 text-pine transition hover:bg-pine/10"
+                                                :aria-label="`Edit ${fullName(g)}`"
+                                            >
+                                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4 12.5-12.5z" />
+                                                </svg>
+                                            </button>
+                                            <button
+                                                type="button"
+                                                @click="openDelete(g)"
+                                                class="rounded-full p-1.5 text-red-700 transition hover:bg-red-700/10"
+                                                :aria-label="`Delete ${fullName(g)}`"
+                                            >
+                                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16M10 11v6M14 11v6M5 7l1 13a2 2 0 002 2h8a2 2 0 002-2l1-13M9 7V4h6v3" />
+                                                </svg>
+                                            </button>
+                                        </div>
                                     </div>
                                 </td>
                             </tr>
 
                             <tr v-if="total === 0">
-                                <td :colspan="isAdmin ? 7 : 6" class="px-5 py-16 text-center">
+                                <td :colspan="isAdmin ? 6 : 5" class="px-5 py-16 text-center">
                                     <p class="text-xl font-display text-pine/70">No golfers found</p>
                                     <p class="mt-1 text-sm text-ink/50">
                                         {{ search ? 'Try a different search.' : 'The roster is empty.' }}
@@ -417,33 +450,58 @@ function toggleExpand(id) {
                                 <dt class="text-ink/50">Email</dt>
                                 <dd class="min-w-0 truncate text-ink/80">{{ g.email || '—' }}</dd>
                             </div>
-                            <div class="flex justify-between gap-3">
-                                <dt class="text-ink/50">Phone</dt>
-                                <dd class="tabular-nums text-ink/80">{{ g.phone || '—' }}</dd>
-                            </div>
                         </dl>
 
-                        <div v-if="isAdmin" class="flex gap-2 mt-4">
-                            <button
-                                type="button"
-                                @click="openEdit(g)"
-                                class="inline-flex items-center gap-1.5 rounded-full border border-pine/20 px-3 py-1.5 text-sm font-medium text-pine transition hover:border-brass"
-                            >
-                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4 12.5-12.5z" />
-                                </svg>
-                                Edit
-                            </button>
-                            <button
-                                type="button"
-                                @click="openDelete(g)"
-                                class="inline-flex items-center gap-1.5 rounded-full border border-red-700/30 px-3 py-1.5 text-sm font-medium text-red-700 transition hover:border-red-700"
-                            >
-                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16M10 11v6M14 11v6M5 7l1 13a2 2 0 002 2h8a2 2 0 002-2l1-13M9 7V4h6v3" />
-                                </svg>
-                                Delete
-                            </button>
+                        <div v-if="isAdmin" class="mt-4 space-y-3">
+                            <!-- Login status / invite -->
+                            <div>
+                                <span
+                                    v-if="g.can_login"
+                                    class="inline-flex items-center gap-1.5 rounded-full bg-pine/10 px-3 py-1 text-sm text-pine"
+                                >
+                                    <span class="h-1.5 w-1.5 rounded-full bg-pine"></span> Active
+                                </span>
+                                <div v-else class="flex flex-wrap items-center gap-2">
+                                    <button
+                                        type="button"
+                                        @click="openInvite(g)"
+                                        class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition"
+                                        :class="g.invited_at
+                                            ? 'border-brass/40 bg-brass/15 text-brass-dark hover:bg-brass/25'
+                                            : 'border-pine/20 text-pine hover:border-brass'"
+                                    >
+                                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                                        </svg>
+                                        {{ g.invited_at ? 'Invite sent' : 'Send Invite' }}
+                                    </button>
+                                    <span v-if="g.invited_at" class="text-xs text-ink/50">Invited {{ g.invited_at }}</span>
+                                </div>
+                            </div>
+
+                            <!-- Edit / delete -->
+                            <div class="flex gap-2">
+                                <button
+                                    type="button"
+                                    @click="openEdit(g)"
+                                    class="inline-flex items-center gap-1.5 rounded-full border border-pine/20 px-3 py-1.5 text-sm font-medium text-pine transition hover:border-brass"
+                                >
+                                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4 12.5-12.5z" />
+                                    </svg>
+                                    Edit
+                                </button>
+                                <button
+                                    type="button"
+                                    @click="openDelete(g)"
+                                    class="inline-flex items-center gap-1.5 rounded-full border border-red-700/30 px-3 py-1.5 text-sm font-medium text-red-700 transition hover:border-red-700"
+                                >
+                                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16M10 11v6M14 11v6M5 7l1 13a2 2 0 002 2h8a2 2 0 002-2l1-13M9 7V4h6v3" />
+                                    </svg>
+                                    Delete
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -469,20 +527,6 @@ function toggleExpand(id) {
             />
         </div>
 
-        <!-- Toast -->
-        <Transition
-            enter-active-class="transition duration-300 ease-out"
-            enter-from-class="translate-y-2 opacity-0"
-            leave-active-class="transition duration-200 ease-in"
-            leave-to-class="translate-y-2 opacity-0"
-        >
-            <div
-                v-if="toast"
-                class="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-full bg-pine px-5 py-2.5 text-sm font-medium text-cream shadow-lg"
-            >
-                {{ toast }}
-            </div>
-        </Transition>
 
         <!-- Add golfers modal -->
         <AddGolfersModal :show="showCreate" @close="showCreate = false" />
@@ -535,8 +579,9 @@ function toggleExpand(id) {
                             <p class="mt-1">
                                 A player's index is normally computed from their logged rounds. Until a
                                 golfer has <span class="font-medium">3</span> rounds there's nothing to
-                                compute, so an established index — a known USGA/GHIN handicap — is required
-                                to gauge their play.
+                                compute, so an established index — a known USGA/GHIN handicap — can
+                                optionally seed their play. Leave it blank to show no index until they
+                                log enough rounds.
                             </p>
                             <p class="mt-2">
                                 Once they reach 3 rounds, their computed index takes over automatically and
@@ -553,7 +598,7 @@ function toggleExpand(id) {
                         readonly
                         class="block w-full mt-2 rounded-lg shadow-sm cursor-not-allowed border-pine/20 bg-parchment tabular-nums text-ink/60 focus:border-pine/20 focus:ring-0"
                     />
-                    <!-- No computed index yet: an established index is required to seed play. -->
+                    <!-- No computed index yet: an established index optionally seeds play. -->
                     <TextInput
                         v-else
                         id="e_index"
@@ -562,7 +607,6 @@ function toggleExpand(id) {
                         step="0.1"
                         min="-9.9"
                         max="54.0"
-                        required
                         class="block w-full mt-2 tabular-nums"
                         placeholder="e.g. 12.3"
                     />
@@ -590,35 +634,10 @@ function toggleExpand(id) {
                         {{
                             editing?.has_computed_index
                                 ? `Calculated from ${editing.number_of_rounds} rounds.`
-                                : 'Required until this golfer has 3 rounds logged.'
+                                : 'Optional — seeds play until this golfer has 3 rounds logged.'
                         }}
                     </p>
                     <InputError :message="editForm.errors.manual_handicap_index" class="mt-1" />
-                </div>
-
-                <!-- Account access -->
-                <div class="pt-4 mt-4 border-t border-parchment-dark">
-                    <InputLabel value="Account access" />
-                    <div v-if="editing?.can_login" class="mt-1.5 inline-flex items-center gap-1.5 rounded-full bg-pine/10 px-3 py-1 text-sm text-pine">
-                        <span class="h-1.5 w-1.5 rounded-full bg-pine"></span> Active login
-                    </div>
-                    <div v-else class="mt-1.5">
-                        <button
-                            type="button"
-                            @click="sendInvite"
-                            :disabled="inviteForm.processing"
-                            class="inline-flex items-center gap-1.5 rounded-full border border-pine/20 px-3 py-1.5 text-sm font-medium text-pine transition hover:border-brass hover:text-brass-dark disabled:opacity-50"
-                        >
-                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M16 12H8m0 0l3-3m-3 3l3 3M3 12a9 9 0 1018 0 9 9 0 00-18 0z" />
-                            </svg>
-                            Invite to log in
-                        </button>
-                        <p class="mt-1 text-xs text-ink/50">
-                            Emails a set-up link to this golfer's saved address — save a real email first if you just edited it.
-                        </p>
-                        <InputError :message="inviteForm.errors.invite" class="mt-1" />
-                    </div>
                 </div>
 
                 <div class="flex justify-end gap-3 mt-6">
@@ -631,6 +650,49 @@ function toggleExpand(id) {
                         class="px-5 py-2 text-sm font-medium transition rounded-full bg-pine text-cream hover:bg-pine-light disabled:opacity-50"
                     >
                         Save changes
+                    </button>
+                </div>
+            </form>
+        </Modal>
+
+        <!-- Invite modal: confirm/update the email, then send the login invite -->
+        <Modal :show="showInvite" @close="showInvite = false" max-width="md">
+            <form @submit.prevent="sendInvite" class="p-6">
+                <h2 class="text-2xl font-semibold font-display text-pine">
+                    {{ inviting?.invited_at ? 'Resend login invite' : 'Invite to log in' }}
+                </h2>
+                <p class="mt-1 text-sm text-ink/60">
+                    We'll email
+                    <span class="font-medium capitalize text-ink">{{ inviting ? fullName(inviting) : '' }}</span>
+                    a link to set up their login so they can manage their own rounds.
+                </p>
+                <p v-if="inviting?.invited_at" class="mt-1 text-xs text-ink/50">
+                    Last invited {{ inviting.invited_at }}.
+                </p>
+
+                <div class="mt-4">
+                    <InputLabel for="invite_email" value="Email" />
+                    <TextInput
+                        id="invite_email"
+                        v-model="inviteForm.email"
+                        type="email"
+                        required
+                        class="block w-full mt-1"
+                        placeholder="player@example.com"
+                    />
+                    <InputError :message="inviteForm.errors.email" class="mt-1" />
+                </div>
+
+                <div class="flex justify-end gap-3 mt-6">
+                    <button type="button" @click="showInvite = false" class="px-4 py-2 text-sm font-medium transition rounded-full text-ink/60 hover:text-ink">
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        :disabled="inviteForm.processing"
+                        class="px-5 py-2 text-sm font-medium transition rounded-full bg-pine text-cream hover:bg-pine-light disabled:opacity-50"
+                    >
+                        {{ inviting?.invited_at ? 'Resend invite' : 'Send invite' }}
                     </button>
                 </div>
             </form>
@@ -668,12 +730,27 @@ function toggleExpand(id) {
         <!-- Delete modal -->
         <Modal :show="showDelete" @close="showDelete = false" max-width="md">
             <div class="p-6">
-                <h2 class="text-2xl font-semibold font-display text-pine">Remove golfer</h2>
-                <p class="mt-2 text-sm text-ink/70">
-                    Remove
-                    <span class="font-semibold capitalize text-ink">{{ deleting ? fullName(deleting) : '' }}</span>
-                    and all of their rounds? This can't be undone.
-                </p>
+                <!-- Removing the owner tears down the whole league. -->
+                <template v-if="deletingOwner">
+                    <h2 class="text-2xl font-semibold font-display text-pine">Delete this league?</h2>
+                    <p class="mt-2 text-sm text-ink/70">
+                        Are you sure you want to delete
+                        <span class="font-semibold text-ink">{{ currentLeague?.name }}</span>
+                        and remove all golfers from it?
+                    </p>
+                    <p class="mt-2 text-sm text-ink/70">
+                        Everyone's historical rounds are preserved for their index — they stay in the
+                        system as casual rounds. You'll be taken back to your leagues.
+                    </p>
+                </template>
+                <template v-else>
+                    <h2 class="text-2xl font-semibold font-display text-pine">Remove golfer</h2>
+                    <p class="mt-2 text-sm text-ink/70">
+                        Remove
+                        <span class="font-semibold capitalize text-ink">{{ deleting ? fullName(deleting) : '' }}</span>
+                        and all of their rounds? This can't be undone.
+                    </p>
+                </template>
                 <div class="flex justify-end gap-3 mt-6">
                     <button type="button" @click="showDelete = false" class="px-4 py-2 text-sm font-medium transition rounded-full text-ink/60 hover:text-ink">
                         Cancel
@@ -684,7 +761,7 @@ function toggleExpand(id) {
                         @click="submitDelete"
                         class="px-5 py-2 text-sm font-medium text-white transition bg-red-700 rounded-full hover:bg-red-800 disabled:opacity-50"
                     >
-                        Yes, remove
+                        {{ deletingOwner ? 'Delete league' : 'Yes, remove' }}
                     </button>
                 </div>
             </div>

--- a/tests/Feature/GolferManagementTest.php
+++ b/tests/Feature/GolferManagementTest.php
@@ -234,19 +234,23 @@ class GolferManagementTest extends TestCase
         ]);
     }
 
-    public function test_a_golfer_without_a_computed_index_requires_an_established_index(): void
+    public function test_the_established_index_is_optional(): void
     {
         $league = League::factory()->create();
         $golfer = $this->golferIn($league); // no rounds -> no computed index
 
+        // Saving without an established index is allowed; it stays unset.
         $this->actingAs($this->adminOf($league))
             ->put(route('golfers.update', $golfer), [
                 'first_name' => 'Jane',
                 'last_name' => 'Doe',
             ])
-            ->assertInvalid('manual_handicap_index');
+            ->assertRedirect()
+            ->assertSessionHasNoErrors();
 
-        // With a seed provided, the update goes through and is stored.
+        $this->assertNull($golfer->fresh()->manual_handicap_index);
+
+        // A seed still stores when provided.
         $this->actingAs($this->adminOf($league))
             ->put(route('golfers.update', $golfer), [
                 'first_name' => 'Jane',
@@ -320,6 +324,54 @@ class GolferManagementTest extends TestCase
         // Detached from the league, but the login account survives.
         $this->assertDatabaseMissing('league_user', ['user_id' => $member->id, 'league_id' => $league->id]);
         $this->assertDatabaseHas('users', ['id' => $member->id]);
+    }
+
+    public function test_removing_the_league_owner_dissolves_the_league_and_keeps_rounds(): void
+    {
+        $league = League::factory()->create();
+        $owner = $this->adminOf($league);
+        $league->update(['owner_id' => $owner->id]);
+
+        // Another golfer, plus rounds for both, all in this league.
+        $golfer = $this->golferIn($league);
+        $ownerRound = $this->roundFor($owner, $league);
+        $golferRound = $this->roundFor($golfer, $league);
+
+        $this->actingAs($owner)
+            ->delete(route('golfers.destroy', $owner))
+            ->assertRedirect(route('leagues'));
+
+        // The league and every membership are gone.
+        $this->assertDatabaseMissing('leagues', ['id' => $league->id]);
+        $this->assertDatabaseMissing('league_user', ['league_id' => $league->id]);
+
+        // No users are deleted, and both rounds survive as casual (league_id null).
+        $this->assertDatabaseHas('users', ['id' => $owner->id]);
+        $this->assertDatabaseHas('users', ['id' => $golfer->id]);
+        $this->assertDatabaseHas('rounds', ['id' => $ownerRound->id, 'league_id' => null]);
+        $this->assertDatabaseHas('rounds', ['id' => $golferRound->id, 'league_id' => null]);
+
+        // The owner is no longer parked on the deleted league.
+        $this->assertNull($owner->fresh()->current_league_id);
+    }
+
+    public function test_a_non_owner_admin_cannot_dissolve_the_league_by_removing_the_owner(): void
+    {
+        $league = League::factory()->create();
+        $owner = $this->adminOf($league);
+        $league->update(['owner_id' => $owner->id]);
+
+        // A second admin who did not create the league.
+        $otherAdmin = User::factory()->create(['current_league_id' => $league->id]);
+        $league->members()->attach($otherAdmin->id, ['role' => 'admin']);
+
+        $this->actingAs($otherAdmin)
+            ->delete(route('golfers.destroy', $owner))
+            ->assertForbidden();
+
+        // The league and the owner's membership are untouched.
+        $this->assertDatabaseHas('leagues', ['id' => $league->id]);
+        $this->assertDatabaseHas('league_user', ['user_id' => $owner->id, 'league_id' => $league->id]);
     }
 
     public function test_any_league_member_can_export_handicaps_pdf(): void

--- a/tests/Feature/InviteTest.php
+++ b/tests/Feature/InviteTest.php
@@ -16,17 +16,34 @@ class InviteTest extends TestCase
 {
     use RefreshDatabase, WithLeague;
 
-    public function test_admin_can_invite_a_player_who_has_a_real_email(): void
+    public function test_admin_can_invite_a_player_with_a_confirmed_email(): void
     {
         Notification::fake();
         $league = League::factory()->create();
-        $player = $this->golferIn($league, ['email' => 'player@example.com']); // login-less, real email
+        $player = $this->golferIn($league, ['email' => 'player@example.com']); // login-less
 
         $this->actingAs($this->adminOf($league))
-            ->post(route('golfers.invite', $player))
-            ->assertRedirect();
+            ->post(route('golfers.invite', $player), ['email' => 'player@example.com'])
+            ->assertRedirect()
+            ->assertSessionHas('invite_link');
 
         Notification::assertSentTo($player, PlayerInvitation::class);
+
+        // The invite is timestamped, so the roster can show "Invited …" + resend.
+        $this->assertNotNull($player->fresh()->invited_at);
+    }
+
+    public function test_inviting_updates_the_players_email(): void
+    {
+        Notification::fake();
+        $league = League::factory()->create();
+        $player = $this->golferIn($league, ['email' => 'old@example.com']);
+
+        $this->actingAs($this->adminOf($league))
+            ->post(route('golfers.invite', $player), ['email' => 'new@example.com'])
+            ->assertRedirect();
+
+        $this->assertSame('new@example.com', $player->fresh()->email);
     }
 
     public function test_invite_still_returns_the_link_when_email_delivery_fails(): void
@@ -44,20 +61,43 @@ class InviteTest extends TestCase
         });
 
         $this->actingAs($this->adminOf($league))
-            ->post(route('golfers.invite', $player))
+            ->post(route('golfers.invite', $player), ['email' => 'player@example.com'])
             ->assertRedirect()           // not a 500
             ->assertSessionHas('invite_link'); // copyable fallback still provided
     }
 
-    public function test_cannot_invite_a_player_without_a_real_email(): void
+    public function test_inviting_requires_an_email(): void
     {
         $league = League::factory()->create();
         $player = $this->golferIn($league, ['email' => null]);
 
         $this->actingAs($this->adminOf($league))
-            ->postJson(route('golfers.invite', $player))
+            ->postJson(route('golfers.invite', $player), [])
             ->assertStatus(422)
-            ->assertJsonValidationErrors(['invite']);
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_cannot_invite_with_an_email_already_in_use(): void
+    {
+        $league = League::factory()->create();
+        $player = $this->golferIn($league, ['email' => 'player@example.com']);
+        User::factory()->create(['email' => 'taken@example.com']);
+
+        $this->actingAs($this->adminOf($league))
+            ->postJson(route('golfers.invite', $player), ['email' => 'TAKEN@example.com']) // case-insensitive
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_cannot_invite_a_noreply_placeholder_email(): void
+    {
+        $league = League::factory()->create();
+        $player = $this->golferIn($league, ['email' => 'player@noreply.com']);
+
+        $this->actingAs($this->adminOf($league))
+            ->postJson(route('golfers.invite', $player), ['email' => 'player@noreply.com'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
     }
 
     public function test_cannot_invite_a_player_who_already_logs_in(): void
@@ -66,9 +106,9 @@ class InviteTest extends TestCase
         $member = $this->playerOf($league); // factory user with a password
 
         $this->actingAs($this->adminOf($league))
-            ->postJson(route('golfers.invite', $member))
+            ->postJson(route('golfers.invite', $member), ['email' => 'x@example.com'])
             ->assertStatus(422)
-            ->assertJsonValidationErrors(['invite']);
+            ->assertJsonValidationErrors(['email']);
     }
 
     public function test_accepting_an_invite_sets_the_password_and_logs_in(): void

--- a/tests/Feature/LeagueManagementTest.php
+++ b/tests/Feature/LeagueManagementTest.php
@@ -265,14 +265,15 @@ class LeagueManagementTest extends TestCase
             ->assertJsonValidationErrors(['name']);
     }
 
-    public function test_an_admin_can_delete_a_league_and_cascade_its_rounds_and_golfers(): void
+    public function test_the_owner_can_delete_a_league_and_keep_rounds_as_casual(): void
     {
         $league = League::factory()->create();
         $admin = $this->adminOf($league);
+        $league->update(['owner_id' => $admin->id]);
 
-        $orphan = $this->golferIn($league);
-        $this->roundFor($orphan, $league);
-        $this->roundFor($orphan, $league);
+        $roster = $this->golferIn($league);
+        $r1 = $this->roundFor($roster, $league);
+        $r2 = $this->roundFor($roster, $league);
 
         // A golfer also on another league must survive (just detached).
         $other = League::factory()->create();
@@ -284,16 +285,37 @@ class LeagueManagementTest extends TestCase
             ->assertRedirect(route('leagues'));
 
         $this->assertDatabaseMissing('leagues', ['id' => $league->id]);
-        $this->assertDatabaseMissing('rounds', ['league_id' => $league->id]);
         $this->assertDatabaseMissing('league_user', ['league_id' => $league->id]);
 
-        // Orphan golfer gone; shared golfer kept (still in the other league).
-        $this->assertDatabaseMissing('users', ['id' => $orphan->id]);
+        // Rounds are preserved as casual (league_id null), not deleted.
+        $this->assertDatabaseHas('rounds', ['id' => $r1->id, 'league_id' => null]);
+        $this->assertDatabaseHas('rounds', ['id' => $r2->id, 'league_id' => null]);
+
+        // No users are deleted — even the login-less roster golfer survives.
+        $this->assertDatabaseHas('users', ['id' => $roster->id]);
         $this->assertDatabaseHas('users', ['id' => $shared->id]);
         $this->assertDatabaseHas('league_user', ['user_id' => $shared->id, 'league_id' => $other->id]);
 
-        // The admin no longer points at the deleted league.
+        // The admin had no other league, so nothing is selected afterwards.
         $this->assertNull($admin->fresh()->current_league_id);
+    }
+
+    public function test_deleting_a_league_selects_the_next_available_league(): void
+    {
+        $keeper = League::factory()->create(['name' => 'aaa keeper']);
+        $doomed = League::factory()->create(['name' => 'zzz doomed']);
+
+        $owner = User::factory()->create(['current_league_id' => $doomed->id]);
+        $doomed->update(['owner_id' => $owner->id]);
+        $doomed->members()->attach($owner->id, ['role' => 'admin']);
+        $keeper->members()->attach($owner->id, ['role' => 'player']);
+
+        $this->actingAs($owner)
+            ->delete(route('leagues.destroy', $doomed))
+            ->assertRedirect(route('leagues'));
+
+        // Parked on the deleted league, they roll onto their remaining one.
+        $this->assertSame($keeper->id, $owner->fresh()->current_league_id);
     }
 
     public function test_a_non_admin_cannot_delete_a_league(): void
@@ -302,6 +324,19 @@ class LeagueManagementTest extends TestCase
         $player = $this->playerOf($league);
 
         $this->actingAs($player)
+            ->delete(route('leagues.destroy', $league))
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('leagues', ['id' => $league->id]);
+    }
+
+    public function test_an_admin_who_is_not_the_owner_cannot_delete_a_league(): void
+    {
+        // Owner is the factory's separate user; this admin didn't create it.
+        $league = League::factory()->create();
+        $admin = $this->adminOf($league);
+
+        $this->actingAs($admin)
             ->delete(route('leagues.destroy', $league))
             ->assertForbidden();
 


### PR DESCRIPTION
- Per-row login invites: status pills (Active/Invite sent), intermediate email modal, unique + noreply validation, invited_at tracking/resend
- Established index now optional
- Owner-only league deletion; unified dissolve keeps rounds as casual and reselects the next league
- Global reusable FlashToast in the layout
- Drop phone from roster table/cards