### PR TITLE
Brand the password-reset email to match the invite email

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Enums\Role;
+use App\Notifications\ResetPasswordNotification;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -102,6 +103,14 @@ class User extends Authenticatable
     public function canLogin(): bool
     {
         return ! is_null($this->password);
+    }
+
+    /**
+     * Send the branded password-reset email instead of Laravel's default.
+     */
+    public function sendPasswordResetNotification(#[\SensitiveParameter] $token): void
+    {
+        $this->notify(new ResetPasswordNotification($token));
     }
 
     /**

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Notifications\Messages\MailMessage;
+
+/**
+ * Branded password-reset email — replaces Laravel's default template with the
+ * GolfTourney-styled one, while reusing the base class's token + URL handling.
+ */
+class ResetPasswordNotification extends ResetPassword
+{
+    public function toMail(mixed $notifiable): MailMessage
+    {
+        $expireMinutes = config('auth.passwords.'.config('auth.defaults.passwords').'.expire', 60);
+
+        return (new MailMessage)
+            ->subject('Reset your GolfTourney password')
+            ->view('emails.reset-password', [
+                'firstName' => ucfirst((string) ($notifiable->first_name ?? '')),
+                'url' => $this->resetUrl($notifiable),
+                'expireMinutes' => $expireMinutes,
+            ]);
+    }
+}

--- a/resources/views/components/branded-email.blade.php
+++ b/resources/views/components/branded-email.blade.php
@@ -1,0 +1,98 @@
+@props([
+    'title' => 'GolfTourney',
+    'heading',
+    'ctaUrl' => null,
+    'ctaLabel' => null,
+    'footnote' => "If you weren't expecting this, you can safely ignore this email.",
+    'message' => null,
+])
+@php
+    // Embed the logo inline (CID) when actually sending so it renders in every
+    // client; fall back to an absolute URL when rendered without a mail message.
+    $logo = $message
+        ? $message->embed(public_path('img/logo-emblem-email.png'))
+        : asset('img/logo-emblem-email.png').'?v=1';
+@endphp
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{{ $title }}</title>
+</head>
+<body style="margin:0; padding:0; width:100%; background-color:#f2eee3; -webkit-text-size-adjust:100%;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2eee3" style="background-color:#f2eee3;">
+        <tr>
+            <td align="center" style="padding:32px 16px;">
+                <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px; max-width:600px; background-color:#faf7ef; border-radius:16px; overflow:hidden; border:1px solid #e8e1d0;">
+                    <!-- Logo -->
+                    <tr>
+                        <td align="center" style="padding:40px 40px 12px 40px;">
+                            <img src="{{ $logo }}" width="112" height="112" alt="GolfTourney" style="display:block; border:0; outline:none; text-decoration:none; width:112px; height:112px;">
+                        </td>
+                    </tr>
+
+                    <!-- Heading -->
+                    <tr>
+                        <td align="center" style="padding:4px 40px 0 40px;">
+                            <h1 style="margin:0; font-family:Fraunces,Georgia,'Times New Roman',serif; font-size:26px; font-weight:600; line-height:1.3; color:#14432f;">
+                                {{ $heading }}
+                            </h1>
+                        </td>
+                    </tr>
+
+                    <!-- Body -->
+                    <tr>
+                        <td style="padding:20px 40px 0 40px; font-family:Figtree,'Helvetica Neue',Helvetica,Arial,sans-serif; font-size:16px; line-height:1.6; color:#1b1d1a;">
+                            {{ $slot }}
+                        </td>
+                    </tr>
+
+                    @if ($ctaUrl && $ctaLabel)
+                        <!-- CTA -->
+                        <tr>
+                            <td align="center" style="padding:28px 40px 4px 40px;">
+                                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td align="center" bgcolor="#14432f" style="border-radius:9999px;">
+                                            <a href="{{ $ctaUrl }}" target="_blank" style="display:inline-block; padding:14px 34px; font-family:Figtree,'Helvetica Neue',Helvetica,Arial,sans-serif; font-size:16px; font-weight:600; color:#faf7ef; text-decoration:none; border-radius:9999px;">
+                                                {{ $ctaLabel }}
+                                            </a>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <!-- Fallback link -->
+                        <tr>
+                            <td style="padding:20px 40px 0 40px; font-family:Figtree,'Helvetica Neue',Helvetica,Arial,sans-serif; font-size:13px; line-height:1.6; color:#6b6f68;">
+                                <p style="margin:0 0 4px 0;">Or paste this link into your browser:</p>
+                                <a href="{{ $ctaUrl }}" style="color:#8a6c3f; text-decoration:underline; word-break:break-all;">{{ $ctaUrl }}</a>
+                            </td>
+                        </tr>
+                    @endif
+
+                    <!-- Divider -->
+                    <tr>
+                        <td style="padding:28px 40px 0 40px;">
+                            <div style="border-top:1px solid #e8e1d0; font-size:0; line-height:0;">&nbsp;</div>
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td align="center" style="padding:16px 40px 40px 40px; font-family:Figtree,'Helvetica Neue',Helvetica,Arial,sans-serif; font-size:12px; line-height:1.6; color:#9a9e96;">
+                            @if ($footnote)
+                                <p style="margin:0 0 8px 0;">{{ $footnote }}</p>
+                            @endif
+                            <p style="margin:0; font-family:Fraunces,Georgia,'Times New Roman',serif; font-size:14px; letter-spacing:1px; color:#b08d57;">GolfTourney</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/resources/views/emails/player-invitation.blade.php
+++ b/resources/views/emails/player-invitation.blade.php
@@ -1,80 +1,10 @@
-<!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Set up your GolfTourney login</title>
-</head>
-<body style="margin:0; padding:0; width:100%; background-color:#f2eee3; -webkit-text-size-adjust:100%;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2eee3" style="background-color:#f2eee3;">
-        <tr>
-            <td align="center" style="padding:32px 16px;">
-                <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px; max-width:600px; background-color:#faf7ef; border-radius:16px; overflow:hidden; border:1px solid #e8e1d0;">
-                    <!-- Logo -->
-                    <tr>
-                        <td align="center" style="padding:40px 40px 12px 40px;">
-                            <img src="{{ isset($message) ? $message->embed(public_path('img/logo-emblem-email.png')) : asset('img/logo-emblem-email.png').'?v=1' }}" width="112" height="112" alt="GolfTourney" style="display:block; border:0; outline:none; text-decoration:none; width:112px; height:112px;">
-                        </td>
-                    </tr>
-
-                    <!-- Heading -->
-                    <tr>
-                        <td align="center" style="padding:4px 40px 0 40px;">
-                            <h1 style="margin:0; font-family:Fraunces,Georgia,'Times New Roman',serif; font-size:26px; font-weight:600; line-height:1.3; color:#14432f;">
-                                You're invited to {{ $leagueName }}
-                            </h1>
-                        </td>
-                    </tr>
-
-                    <!-- Body -->
-                    <tr>
-                        <td style="padding:20px 40px 0 40px; font-family:Figtree,'Helvetica Neue',Helvetica,Arial,sans-serif; font-size:16px; line-height:1.6; color:#1b1d1a;">
-                            <p style="margin:0 0 16px 0;">Hi {{ $firstName }},</p>
-                            <p style="margin:0;">You've been invited to join <strong style="color:#14432f;">{{ $leagueName }}</strong> and manage your handicap on GolfTourney — track your rounds and keep your Handicap Index up to date.</p>
-                        </td>
-                    </tr>
-
-                    <!-- CTA -->
-                    <tr>
-                        <td align="center" style="padding:28px 40px 4px 40px;">
-                            <table role="presentation" cellpadding="0" cellspacing="0" border="0">
-                                <tr>
-                                    <td align="center" bgcolor="#14432f" style="border-radius:9999px;">
-                                        <a href="{{ $url }}" target="_blank" style="display:inline-block; padding:14px 34px; font-family:Figtree,'Helvetica Neue',Helvetica,Arial,sans-serif; font-size:16px; font-weight:600; color:#faf7ef; text-decoration:none; border-radius:9999px;">
-                                            Set up your account
-                                        </a>
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
-
-                    <!-- Fallback link -->
-                    <tr>
-                        <td style="padding:20px 40px 0 40px; font-family:Figtree,'Helvetica Neue',Helvetica,Arial,sans-serif; font-size:13px; line-height:1.6; color:#6b6f68;">
-                            <p style="margin:0 0 4px 0;">Or paste this link into your browser:</p>
-                            <a href="{{ $url }}" style="color:#8a6c3f; text-decoration:underline; word-break:break-all;">{{ $url }}</a>
-                        </td>
-                    </tr>
-
-                    <!-- Divider -->
-                    <tr>
-                        <td style="padding:28px 40px 0 40px;">
-                            <div style="border-top:1px solid #e8e1d0; font-size:0; line-height:0;">&nbsp;</div>
-                        </td>
-                    </tr>
-
-                    <!-- Footer -->
-                    <tr>
-                        <td align="center" style="padding:16px 40px 40px 40px; font-family:Figtree,'Helvetica Neue',Helvetica,Arial,sans-serif; font-size:12px; line-height:1.6; color:#9a9e96;">
-                            <p style="margin:0 0 8px 0;">If you weren't expecting this, you can safely ignore this email.</p>
-                            <p style="margin:0; font-family:Fraunces,Georgia,'Times New Roman',serif; font-size:14px; letter-spacing:1px; color:#b08d57;">GolfTourney</p>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
+<x-branded-email
+    title="Set up your GolfTourney login"
+    heading="You're invited to {{ $leagueName }}"
+    :cta-url="$url"
+    cta-label="Set up your account"
+    :message="$message ?? null"
+>
+    <p style="margin:0 0 16px 0;">Hi {{ $firstName }},</p>
+    <p style="margin:0;">You've been invited to join <strong style="color:#14432f;">{{ $leagueName }}</strong> and manage your handicap on GolfTourney — track your rounds and keep your Handicap Index up to date.</p>
+</x-branded-email>

--- a/resources/views/emails/reset-password.blade.php
+++ b/resources/views/emails/reset-password.blade.php
@@ -1,0 +1,11 @@
+<x-branded-email
+    title="Reset your GolfTourney password"
+    heading="Reset your password"
+    :cta-url="$url"
+    cta-label="Reset password"
+    :message="$message ?? null"
+>
+    <p style="margin:0 0 16px 0;">Hi {{ $firstName }},</p>
+    <p style="margin:0 0 16px 0;">We received a request to reset the password for your GolfTourney account. Tap the button below to choose a new one.</p>
+    <p style="margin:0;">This link expires in {{ $expireMinutes }} minutes. If you didn't request a reset, you can safely ignore this email — your password won't change.</p>
+</x-branded-email>

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
-use Illuminate\Auth\Notifications\ResetPassword;
+use App\Notifications\ResetPasswordNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
@@ -27,7 +27,7 @@ class PasswordResetTest extends TestCase
 
         $this->post('/forgot-password', ['email' => $user->email]);
 
-        Notification::assertSentTo($user, ResetPassword::class);
+        Notification::assertSentTo($user, ResetPasswordNotification::class);
     }
 
     public function test_reset_password_screen_can_be_rendered(): void
@@ -38,13 +38,25 @@ class PasswordResetTest extends TestCase
 
         $this->post('/forgot-password', ['email' => $user->email]);
 
-        Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
+        Notification::assertSentTo($user, ResetPasswordNotification::class, function ($notification) {
             $response = $this->get('/reset-password/'.$notification->token);
 
             $response->assertStatus(200);
 
             return true;
         });
+    }
+
+    public function test_the_reset_password_email_renders_with_branding(): void
+    {
+        $user = User::factory()->create(['first_name' => 'jane']);
+
+        $rendered = (new ResetPasswordNotification('some-token'))->toMail($user)->render();
+
+        $this->assertStringContainsString('Reset password', $rendered);      // CTA label
+        $this->assertStringContainsString('alt="GolfTourney"', $rendered);   // branded logo
+        $this->assertStringContainsString('Hi Jane,', $rendered);            // capitalized name
+        $this->assertStringContainsString('reset-password/some-token', $rendered); // reset link
     }
 
     public function test_password_can_be_reset_with_valid_token(): void
@@ -55,7 +67,7 @@ class PasswordResetTest extends TestCase
 
         $this->post('/forgot-password', ['email' => $user->email]);
 
-        Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
+        Notification::assertSentTo($user, ResetPasswordNotification::class, function ($notification) use ($user) {
             $response = $this->post('/reset-password', [
                 'token' => $notification->token,
                 'email' => $user->email,


### PR DESCRIPTION
- Extract a reusable branded-email component (logo, palette, CTA, footer)
- Refactor the invite email onto it
- Add a branded password-reset notification + view, wired via User::sendPasswordResetNotification, replacing Laravel's default template