### PR TITLE
Validate unique email on golfer update

### DIFF
--- a/app/Http/Requests/UpdateGolferRequest.php
+++ b/app/Http/Requests/UpdateGolferRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests;
 
+use App\Models\User;
+use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateGolferRequest extends FormRequest
@@ -19,6 +21,9 @@ class UpdateGolferRequest extends FormRequest
      */
     public function rules(): array
     {
+        $user = $this->route('user');
+        $userId = $user instanceof User ? $user->id : null;
+
         // The established index is an optional seed: while a golfer has too few
         // rounds to compute an index (handicap_index stays null below the
         // 3-round minimum) it's how you can gauge their play, but it's never
@@ -26,7 +31,24 @@ class UpdateGolferRequest extends FormRequest
         return [
             'first_name' => 'required|string|max:255',
             'last_name' => 'required|string|max:255',
-            'email' => 'nullable|email|max:255',
+            // Email uniquely identifies a person, so it can't already belong to a
+            // different account (case-insensitive, matching the invite flow).
+            'email' => [
+                'nullable', 'email', 'max:255',
+                function (string $attribute, mixed $value, Closure $fail) use ($userId): void {
+                    if ($value === null || $value === '') {
+                        return;
+                    }
+
+                    $taken = User::whereRaw('lower(email) = ?', [mb_strtolower(trim((string) $value))])
+                        ->when($userId, fn ($q) => $q->where('id', '!=', $userId))
+                        ->exists();
+
+                    if ($taken) {
+                        $fail('This email is already in use.');
+                    }
+                },
+            ],
             'phone' => 'nullable|string|max:255',
             'manual_handicap_index' => ['nullable', 'numeric', 'between:-9.9,54.0'],
         ];

--- a/tests/Feature/GolferManagementTest.php
+++ b/tests/Feature/GolferManagementTest.php
@@ -234,6 +234,40 @@ class GolferManagementTest extends TestCase
         ]);
     }
 
+    public function test_updating_a_golfer_to_an_email_in_use_is_rejected(): void
+    {
+        $league = League::factory()->create();
+        $golfer = $this->golferIn($league);
+        User::factory()->create(['email' => 'taken@example.com']);
+
+        // A duplicate email is a validation error, not a 500 from the DB.
+        $this->actingAs($this->adminOf($league))
+            ->put(route('golfers.update', $golfer), [
+                'first_name' => 'Jane',
+                'last_name' => 'Doe',
+                'email' => 'TAKEN@example.com', // case-insensitive
+                'manual_handicap_index' => 12.3,
+            ])
+            ->assertInvalid('email');
+    }
+
+    public function test_updating_a_golfer_keeps_their_own_email(): void
+    {
+        $league = League::factory()->create();
+        $golfer = $this->golferIn($league, ['email' => 'mine@example.com']);
+
+        // Re-saving with the golfer's own email is not a collision.
+        $this->actingAs($this->adminOf($league))
+            ->put(route('golfers.update', $golfer), [
+                'first_name' => 'Jane',
+                'last_name' => 'Doe',
+                'email' => 'mine@example.com',
+                'manual_handicap_index' => 12.3,
+            ])
+            ->assertRedirect()
+            ->assertSessionHasNoErrors();
+    }
+
     public function test_the_established_index_is_optional(): void
     {
         $league = League::factory()->create();


### PR DESCRIPTION
Edit modal now shows "email already in use" instead of a 500 on a duplicate; matches the invite flow's case-insensitive check.