### PR TITLE
Lock golfer edits for users with their own login

### DIFF
--- a/app/Http/Controllers/GolfersController.php
+++ b/app/Http/Controllers/GolfersController.php
@@ -307,6 +307,11 @@ class GolfersController extends Controller
     {
         $this->authorizeUser($request, $user);
 
+        // Once a golfer has their own login they manage their own account — an
+        // admin must not be able to change their email/details (that would open
+        // an account-takeover path). Their profile is theirs to edit.
+        abort_if($user->canLogin(), 403);
+
         $attributes = [
             'first_name' => strtolower($request->input('first_name')),
             'last_name' => strtolower($request->input('last_name')),

--- a/resources/js/Pages/Golfers/Index.vue
+++ b/resources/js/Pages/Golfers/Index.vue
@@ -77,6 +77,9 @@ const editForm = useForm({
     phone: '',
     manual_handicap_index: '',
 });
+// A golfer with their own login manages their own account, so the edit modal
+// is read-only for them (the backend also rejects such edits — see update()).
+const editLocked = computed(() => !!editing.value?.can_login);
 function openEdit(golfer) {
     editing.value = golfer;
     editForm.clearErrors();
@@ -546,27 +549,29 @@ function toggleExpand(id) {
                         {{ editing.number_of_rounds === 1 ? 'round' : 'rounds' }}
                     </span>
                 </div>
-                <p class="mt-1 text-sm text-ink/60">Update this golfer's details.</p>
+                <p class="mt-1 text-sm text-ink/60">
+                    {{ editLocked ? 'This golfer has their own login and manages their own account, so their details are read-only.' : "Update this golfer's details." }}
+                </p>
 
                 <div class="grid grid-cols-1 gap-4 mt-5 sm:grid-cols-2">
                     <div>
                         <InputLabel for="e_first" value="First name" />
-                        <TextInput id="e_first" v-model="editForm.first_name" type="text" class="block w-full mt-1 capitalize" required />
+                        <TextInput id="e_first" v-model="editForm.first_name" type="text" :disabled="editLocked" class="block w-full mt-1 capitalize disabled:cursor-not-allowed disabled:bg-parchment disabled:text-ink/50" required />
                         <InputError :message="editForm.errors.first_name" class="mt-1" />
                     </div>
                     <div>
                         <InputLabel for="e_last" value="Last name" />
-                        <TextInput id="e_last" v-model="editForm.last_name" type="text" class="block w-full mt-1 capitalize" required />
+                        <TextInput id="e_last" v-model="editForm.last_name" type="text" :disabled="editLocked" class="block w-full mt-1 capitalize disabled:cursor-not-allowed disabled:bg-parchment disabled:text-ink/50" required />
                         <InputError :message="editForm.errors.last_name" class="mt-1" />
                     </div>
                     <div>
                         <InputLabel for="e_phone" value="Phone" />
-                        <TextInput id="e_phone" v-model="editForm.phone" type="text" class="block w-full mt-1" />
+                        <TextInput id="e_phone" v-model="editForm.phone" type="text" :disabled="editLocked" class="block w-full mt-1 disabled:cursor-not-allowed disabled:bg-parchment disabled:text-ink/50" />
                         <InputError :message="editForm.errors.phone" class="mt-1" />
                     </div>
                     <div>
                         <InputLabel for="e_email" value="Email" />
-                        <TextInput id="e_email" v-model="editForm.email" type="email" class="block w-full mt-1" />
+                        <TextInput id="e_email" v-model="editForm.email" type="email" :disabled="editLocked" class="block w-full mt-1 disabled:cursor-not-allowed disabled:bg-parchment disabled:text-ink/50" />
                         <InputError :message="editForm.errors.email" class="mt-1" />
                     </div>
                 </div>
@@ -607,12 +612,13 @@ function toggleExpand(id) {
                         step="0.1"
                         min="-9.9"
                         max="54.0"
-                        class="block w-full mt-2 tabular-nums"
+                        :disabled="editLocked"
+                        class="block w-full mt-2 tabular-nums disabled:cursor-not-allowed disabled:bg-parchment disabled:text-ink/50"
                         placeholder="e.g. 12.3"
                     />
 
                     <!-- Quick presets to seed a rough index when the exact number isn't known. -->
-                    <div v-if="!editing?.has_computed_index" class="flex flex-wrap items-center gap-1.5 mt-2">
+                    <div v-if="!editing?.has_computed_index && !editLocked" class="flex flex-wrap items-center gap-1.5 mt-2">
                         <span class="text-xs text-ink/50">Quick set:</span>
                         <button
                             v-for="preset in indexPresets"
@@ -641,16 +647,23 @@ function toggleExpand(id) {
                 </div>
 
                 <div class="flex justify-end gap-3 mt-6">
-                    <button type="button" @click="showEdit = false" class="px-4 py-2 text-sm font-medium transition rounded-full text-ink/60 hover:text-ink">
-                        Cancel
-                    </button>
-                    <button
-                        type="submit"
-                        :disabled="editForm.processing"
-                        class="px-5 py-2 text-sm font-medium transition rounded-full bg-pine text-cream hover:bg-pine-light disabled:opacity-50"
-                    >
-                        Save changes
-                    </button>
+                    <template v-if="editLocked">
+                        <button type="button" @click="showEdit = false" class="px-5 py-2 text-sm font-medium transition rounded-full bg-pine text-cream hover:bg-pine-light">
+                            Close
+                        </button>
+                    </template>
+                    <template v-else>
+                        <button type="button" @click="showEdit = false" class="px-4 py-2 text-sm font-medium transition rounded-full text-ink/60 hover:text-ink">
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            :disabled="editForm.processing"
+                            class="px-5 py-2 text-sm font-medium transition rounded-full bg-pine text-cream hover:bg-pine-light disabled:opacity-50"
+                        >
+                            Save changes
+                        </button>
+                    </template>
                 </div>
             </form>
         </Modal>

--- a/tests/Feature/GolferManagementTest.php
+++ b/tests/Feature/GolferManagementTest.php
@@ -234,6 +234,26 @@ class GolferManagementTest extends TestCase
         ]);
     }
 
+    public function test_admin_cannot_edit_a_golfer_who_has_their_own_login(): void
+    {
+        $league = League::factory()->create();
+
+        // A login-capable member (has a password) manages their own account.
+        $member = User::factory()->create(['email' => 'member@example.com']);
+        $member->leagues()->attach($league->id, ['role' => 'player']);
+
+        $this->actingAs($this->adminOf($league))
+            ->put(route('golfers.update', $member), [
+                'first_name' => 'Hacked',
+                'last_name' => 'Name',
+                'email' => 'attacker@example.com',
+            ])
+            ->assertForbidden();
+
+        // The account is untouched — no takeover vector.
+        $this->assertSame('member@example.com', $member->fresh()->email);
+    }
+
     public function test_updating_a_golfer_to_an_email_in_use_is_rejected(): void
     {
         $league = League::factory()->create();


### PR DESCRIPTION
Admins can no longer change a login user's account details — update() now 403s on canLogin() (prevents email-swap takeover); edit modal shows read-only fields + a Close button for those golfers.